### PR TITLE
feat: improve slash command with grouped blocks and mobile support

### DIFF
--- a/components/editor/block-menu.tsx
+++ b/components/editor/block-menu.tsx
@@ -55,7 +55,25 @@ export function BlockMenu({ editor }: BlockMenuProps) {
   const [query, setQuery] = useState('')
   const [position, setPosition] = useState({ top: 0, left: 0 })
   const menuRef = useRef<HTMLDivElement>(null)
+  const groupedListRef = useRef<HTMLDivElement>(null)
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([])
   const [selectedIndex, setSelectedIndex] = useState(0)
+
+  useEffect(() => {
+    if (isVisible && itemRefs.current[selectedIndex]) {
+      setTimeout(() => {
+        itemRefs.current[selectedIndex]?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+        })
+      }, 50)
+    }
+  }, [selectedIndex, isVisible])
+
+  useEffect(() => {
+    itemRefs.current = []
+    setSelectedIndex(0)
+  }, [query])
 
   type BlockGroup = {
     title: string
@@ -63,6 +81,18 @@ export function BlockMenu({ editor }: BlockMenuProps) {
   }
 
   const BLOCK_GROUPS = React.useMemo<BlockGroup[]>(() => [
+    {
+      title: t('blockGroups.basic', { default: 'Básico' }),
+      items: [
+        { label: t('blocks.h1', { default: 'Título 1' }), icon: Heading1, command: (e) => e.chain().focus().toggleHeading({ level: 1 }).run() },
+        { label: t('blocks.h2', { default: 'Título 2' }), icon: Heading2, command: (e) => e.chain().focus().toggleHeading({ level: 2 }).run() },
+        { label: t('blocks.h3', { default: 'Título 3' }), icon: Heading3, command: (e) => e.chain().focus().toggleHeading({ level: 3 }).run() },
+        { label: t('blocks.text', { default: 'Texto Livre' }), icon: Type, command: (e) => e.chain().focus().setParagraph().run() },
+        { label: t('blocks.bold', { default: 'Negrito' }), icon: Bold, command: (e) => e.chain().focus().toggleBold().run() },
+        { label: t('blocks.italic', { default: 'Itálico' }), icon: Italic, command: (e) => e.chain().focus().toggleItalic().run() },
+        { label: t('blocks.underline', { default: 'Sublinhado' }), icon: Underline, command: (e) => e.chain().focus().toggleUnderline().run() },
+      ]
+    },
     {
       title: t('blockGroups.sections', { default: 'Seções' }),
       items: [
@@ -74,18 +104,6 @@ export function BlockMenu({ editor }: BlockMenuProps) {
         { label: t('blocks.point', { default: 'Ponto Principal' }), icon: Pin, command: (e) => e.chain().focus().insertContent({ type: 'pointBlock' }).run() },
         { label: t('blocks.intro', { default: 'Introdução' }), icon: PlayCircle, command: (e) => e.chain().focus().insertContent({ type: 'introBlock' }).run() },
         { label: t('blocks.conclusion', { default: 'Conclusão' }), icon: CheckCircle, command: (e) => e.chain().focus().insertContent({ type: 'conclusionBlock' }).run() },
-      ]
-    },
-    {
-      title: t('blockGroups.basic', { default: 'Básico' }),
-      items: [
-        { label: t('blocks.h1', { default: 'Título 1' }), icon: Heading1, command: (e) => e.chain().focus().toggleHeading({ level: 1 }).run() },
-        { label: t('blocks.h2', { default: 'Título 2' }), icon: Heading2, command: (e) => e.chain().focus().toggleHeading({ level: 2 }).run() },
-        { label: t('blocks.h3', { default: 'Título 3' }), icon: Heading3, command: (e) => e.chain().focus().toggleHeading({ level: 3 }).run() },
-        { label: t('blocks.text', { default: 'Texto Livre' }), icon: Type, command: (e) => e.chain().focus().setParagraph().run() },
-        { label: t('blocks.bold', { default: 'Negrito' }), icon: Bold, command: (e) => e.chain().focus().toggleBold().run() },
-        { label: t('blocks.italic', { default: 'Itálico' }), icon: Italic, command: (e) => e.chain().focus().toggleItalic().run() },
-        { label: t('blocks.underline', { default: 'Sublinhado' }), icon: Underline, command: (e) => e.chain().focus().toggleUnderline().run() },
       ]
     }
   ], [t])
@@ -145,38 +163,43 @@ export function BlockMenu({ editor }: BlockMenuProps) {
         }
         if (event.key === 'ArrowDown') {
           event.preventDefault()
-          setSelectedIndex(prev => (prev + 1) % filteredItems.length)
+          setSelectedIndex(prev => (prev + 1) % BLOCK_ITEMS.length)
           return
         }
         if (event.key === 'ArrowUp') {
           event.preventDefault()
-          setSelectedIndex(prev => (prev - 1 + filteredItems.length) % filteredItems.length)
+          setSelectedIndex(prev => (prev - 1 + BLOCK_ITEMS.length) % BLOCK_ITEMS.length)
           return
         }
         if (event.key === 'Enter') {
           event.preventDefault()
-          if (filteredItems[selectedIndex]) {
-            handleItemSelect(filteredItems[selectedIndex])
+          if (filteredItems.length > 0) {
+            const itemToSelect = filteredItems[selectedIndex] || filteredItems[0]
+            handleItemSelect(itemToSelect)
           }
           return
         }
         return
       }
 
-      if (editor.isFocused && event.key === '/') {
-        event.preventDefault()
-        const { state } = editor
-        const { from } = state.selection
-        const coords = editor.view.coordsAtPos(from)
-        
-        setIsVisible(true)
-        setQuery('')
-        setSelectedIndex(0)
-        
-        // Only use coords on desktop
-        if (!isMobile) {
+      if (event.key === '/') {
+        if (isMobile) {
+          event.preventDefault()
+          setIsVisible(true)
+          setQuery('')
+          setSelectedIndex(0)
+        } else {
+          event.preventDefault()
+          const { state } = editor
+          const { from } = state.selection
+          const coords = editor.view.coordsAtPos(from)
+          
+          setIsVisible(true)
+          setQuery('')
+          setSelectedIndex(0)
+          
           setPosition({ 
-            top: coords.bottom + window.scrollY, 
+            top: window.scrollY + 20, 
             left: coords.left + window.scrollX 
           })
         }
@@ -185,7 +208,7 @@ export function BlockMenu({ editor }: BlockMenuProps) {
 
     document.addEventListener('keydown', handleGlobalKeyDown)
     return () => document.removeEventListener('keydown', handleGlobalKeyDown)
-  }, [editor, isVisible, filteredItems, selectedIndex, handleItemSelect, isMobile])
+  }, [editor, isVisible, filteredItems, selectedIndex, handleItemSelect, isMobile, BLOCK_ITEMS])
 
   useEffect(() => {
     if (!isVisible || isMobile) return
@@ -200,27 +223,106 @@ export function BlockMenu({ editor }: BlockMenuProps) {
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [isVisible, isMobile])
 
-  const MenuList = (
-    <div className="max-h-80 overflow-y-auto p-1 space-y-0.5">
-      {filteredItems.length === 0 ? (
-        <div className="px-2 py-1 text-sm text-muted-foreground">
-          {t('noResults', { default: 'Nenhum resultado encontrado' })}
-        </div>
-      ) : (
-        filteredItems.map((item, index) => (
-          <button
-            key={index}
-            className={`w-full text-left flex items-center space-x-2 px-2 py-2 text-sm rounded transition-colors ${
-              index === selectedIndex ? 'bg-primary text-primary-foreground' : 'hover:bg-muted/80'
-            }`}
-            onClick={() => handleItemSelect(item)}
-            onMouseEnter={() => !isMobile && setSelectedIndex(index)}
-          >
-            <item.icon className={`h-4 w-4 ${index === selectedIndex ? 'text-primary-foreground' : 'text-muted-foreground'}`} />
-            <span>{item.label}</span>
-          </button>
-        ))
-      )}
+  useEffect(() => {
+    if (!isVisible || !isMobile) return
+
+    const handleMobileKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsVisible(false)
+        return
+      }
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        setSelectedIndex(prev => (prev + 1) % BLOCK_ITEMS.length)
+        return
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        setSelectedIndex(prev => (prev - 1 + BLOCK_ITEMS.length) % BLOCK_ITEMS.length)
+        return
+      }
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        if (filteredItems.length > 0) {
+          const itemToSelect = filteredItems[selectedIndex] || filteredItems[0]
+          handleItemSelect(itemToSelect)
+        }
+        return
+      }
+    }
+
+    document.addEventListener('keydown', handleMobileKeyDown)
+    return () => document.removeEventListener('keydown', handleMobileKeyDown)
+  }, [isVisible, isMobile, filteredItems, selectedIndex, handleItemSelect, BLOCK_ITEMS])
+
+  const MenuList = ({ grouped = false }: { grouped?: boolean }): React.ReactNode => {
+    const flatItems = grouped 
+      ? BLOCK_GROUPS.flatMap(group => group.items).filter(item => 
+          item.label.toLowerCase().includes(query.toLowerCase())
+        )
+      : filteredItems
+
+    return (
+      <div className="max-h-80 overflow-y-auto p-1 space-y-0.5">
+        {flatItems.length === 0 ? (
+          <div className="px-2 py-1 text-sm text-muted-foreground">
+            {t('noResults', { default: 'Nenhum resultado encontrado' })}
+          </div>
+        ) : (
+          flatItems.map((item, index) => (
+            <button
+              key={index}
+              ref={(el) => { itemRefs.current[index] = el }}
+              className={`w-full text-left flex items-center space-x-2 px-2 py-2 text-sm rounded transition-colors ${
+                index === selectedIndex ? 'bg-primary text-primary-foreground' : 'hover:bg-muted/80'
+              }`}
+              onClick={() => handleItemSelect(item)}
+              onMouseEnter={() => !isMobile && setSelectedIndex(index)}
+            >
+              <item.icon className={`h-4 w-4 ${index === selectedIndex ? 'text-primary-foreground' : 'text-muted-foreground'}`} />
+              <span>{item.label}</span>
+            </button>
+          ))
+        )}
+      </div>
+    )
+  }
+
+  const GroupedMenuList = () => (
+    <div ref={groupedListRef} className="max-h-[60vh] overflow-y-auto">
+      {BLOCK_GROUPS.map((group, groupIndex) => {
+        const groupFilteredItems = group.items.filter(item => 
+          item.label.toLowerCase().includes(query.toLowerCase())
+        )
+        if (groupFilteredItems.length === 0) return null
+        
+        return (
+          <div key={groupIndex} className="mb-4">
+            <div className="px-3 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              {group.title}
+            </div>
+            <div className="space-y-0.5">
+              {groupFilteredItems.map((item, index) => {
+                const globalIndex = BLOCK_GROUPS.slice(0, groupIndex).reduce((acc, g) => acc + g.items.length, 0) + index
+                return (
+                  <button
+                    key={globalIndex}
+                    ref={(el) => { itemRefs.current[globalIndex] = el }}
+                    className={`w-full text-left flex items-center space-x-2 px-3 py-2.5 text-sm rounded transition-colors ${
+                      globalIndex === selectedIndex ? 'bg-primary text-primary-foreground' : 'hover:bg-muted/80'
+                    }`}
+                    onClick={() => handleItemSelect(item)}
+                    onMouseEnter={() => !isMobile && setSelectedIndex(globalIndex)}
+                  >
+                    <item.icon className={`h-4 w-4 ${globalIndex === selectedIndex ? 'text-primary-foreground' : 'text-muted-foreground'}`} />
+                    <span>{item.label}</span>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )
+      })}
     </div>
   )
 
@@ -246,11 +348,10 @@ export function BlockMenu({ editor }: BlockMenuProps) {
               }}
               placeholder="Pesquisar..."
               className="w-full bg-muted/50 border border-input rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-              autoFocus
             />
           </div>
           <div className="px-3 pb-4">
-            {MenuList}
+            <GroupedMenuList />
           </div>
         </DrawerContent>
       </Drawer>
@@ -260,7 +361,7 @@ export function BlockMenu({ editor }: BlockMenuProps) {
   return (
     <div
       ref={menuRef}
-      className="fixed z-50 mt-1 w-64 rounded-md bg-card border border-border shadow-2xl p-1 overflow-hidden"
+      className="fixed z-50 mt-1 w-80 rounded-md bg-card border border-border shadow-2xl p-1 overflow-hidden"
       style={{
         top: position.top,
         left: position.left,
@@ -279,7 +380,7 @@ export function BlockMenu({ editor }: BlockMenuProps) {
           autoFocus
         />
       </div>
-      {MenuList}
+      <GroupedMenuList />
     </div>
   )
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -117,6 +117,10 @@
       "italic": "Italic",
       "underline": "Underline"
     },
+    "blockGroups": {
+      "sections": "Sections",
+      "basic": "Basic"
+    },
     "verse": {
       "reference": "Reference",
       "search": "Search verse",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -117,6 +117,10 @@
       "italic": "Itálico",
       "underline": "Sublinhado"
     },
+    "blockGroups": {
+      "sections": "Seções",
+      "basic": "Básico"
+    },
     "verse": {
       "reference": "Referência",
       "search": "Buscar versículo",


### PR DESCRIPTION
- Position menu at top of viewport aligned with cursor
- Add scroll-into-view for arrow key navigation
- Group blocks in Basic and Sections (Basic first)
- Add mobile drawer with keyboard navigation
- Remove autoFocus from mobile search input
- Add translations for block groups