### PR TITLE
fix(editor): auto-adjust text color based on cell background

### DIFF
--- a/components/editor/editor.css
+++ b/components/editor/editor.css
@@ -622,24 +622,23 @@
   vertical-align: top;
   box-sizing: border-box;
   min-width: 50px;
-  color: var(--foreground);
 }
 
-/* Ensure text stays readable on colored backgrounds */
-.tiptap table td[style*="background"],
-.tiptap table th[style*="background"] {
-  color: var(--foreground) !important;
-}
-
+/* Ensure text color is inherited from parent cell */
 .tiptap table td p,
 .tiptap table th p {
   color: inherit;
 }
 
+/* Default header styling (no background set) */
 .tiptap table th {
-  background: var(--muted);
   font-weight: 600;
   text-align: left;
+}
+
+.tiptap table th:not([style*="background"]) {
+  background: var(--muted);
+  color: var(--foreground);
 }
 
 .tiptap table .selectedCell {

--- a/components/editor/extensions/custom-table.ts
+++ b/components/editor/extensions/custom-table.ts
@@ -4,6 +4,61 @@ import { Table, TableCell, TableRow as TableRowExtension, TableHeader } from "@t
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { TableView } from "./table-view";
 
+function getLuminance(hex: string): number {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return 1;
+  const [r, g, b] = [rgb.r, rgb.g, rgb.b].map((c) => {
+    c = c / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  hex = hex.replace(/^#/, "");
+  if (hex.length === 3) {
+    hex = hex
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
+  if (hex.length !== 6) return null;
+  const result = /^([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return result
+    ? {
+        r: parseInt(result[1], 16),
+        g: parseInt(result[2], 16),
+        b: parseInt(result[3], 16),
+      }
+    : null;
+}
+
+function getTextColor(bgColor: string | null): string {
+  if (!bgColor || bgColor === "transparent") {
+    return "inherit";
+  }
+  const luminance = getLuminance(bgColor);
+  return luminance > 0.5 ? "#1f2937" : "#f9fafb";
+}
+
+function buildStyle(attributes: Record<string, unknown>, existingStyle?: string): string {
+  const styles: string[] = [];
+  if (existingStyle) styles.push(existingStyle);
+  
+  const bgColor = attributes.backgroundColor as string | null;
+  if (bgColor && bgColor !== "transparent") {
+    styles.push(`background-color: ${bgColor}`);
+    styles.push(`color: ${getTextColor(bgColor)}`);
+  }
+  
+  const textAlign = attributes.textAlign as string | null;
+  if (textAlign) {
+    styles.push(`text-align: ${textAlign}`);
+  }
+  
+  return styles.join("; ");
+}
+
 export const CustomTable = Table.extend({
   addNodeView() {
     return ReactNodeViewRenderer(TableView);
@@ -18,20 +73,18 @@ export const CustomTableCell = TableCell.extend({
         default: null,
         parseHTML: (element) => element.style.backgroundColor || null,
         renderHTML: (attributes) => {
-          if (!attributes.backgroundColor) return {};
-          return {
-            style: `background-color: ${attributes.backgroundColor}`,
-          };
+          const style = buildStyle(attributes);
+          if (!style) return {};
+          return { style };
         },
       },
       textAlign: {
         default: null,
         parseHTML: (element) => element.style.textAlign || null,
         renderHTML: (attributes) => {
-          if (!attributes.textAlign) return {};
-          return {
-            style: `text-align: ${attributes.textAlign}`,
-          };
+          if (!attributes.textAlign && !attributes.backgroundColor) return {};
+          const style = buildStyle(attributes);
+          return { style };
         },
       },
     };
@@ -46,20 +99,18 @@ export const CustomTableHeader = TableHeader.extend({
         default: null,
         parseHTML: (element) => element.style.backgroundColor || null,
         renderHTML: (attributes) => {
-          if (!attributes.backgroundColor) return {};
-          return {
-            style: `background-color: ${attributes.backgroundColor}`,
-          };
+          const style = buildStyle(attributes);
+          if (!style) return {};
+          return { style };
         },
       },
       textAlign: {
         default: null,
         parseHTML: (element) => element.style.textAlign || null,
         renderHTML: (attributes) => {
-          if (!attributes.textAlign) return {};
-          return {
-            style: `text-align: ${attributes.textAlign}`,
-          };
+          if (!attributes.textAlign && !attributes.backgroundColor) return {};
+          const style = buildStyle(attributes);
+          return { style };
         },
       },
     };
@@ -74,10 +125,9 @@ export const CustomTableRow = TableRowExtension.extend({
         default: null,
         parseHTML: (element) => element.style.backgroundColor || null,
         renderHTML: (attributes) => {
-          if (!attributes.backgroundColor) return {};
-          return {
-            style: `background-color: ${attributes.backgroundColor}`,
-          };
+          const style = buildStyle(attributes);
+          if (!style) return {};
+          return { style };
         },
       },
     };


### PR DESCRIPTION
## Summary
- Automatically adjust text color based on cell background luminance
- Light backgrounds get dark text (#1f2937)
- Dark backgrounds get light text (#f9fafb)
- Remove hardcoded `!important` color override in CSS

## How it works
The `getLuminance()` function calculates the relative luminance of the background color:
- If luminance > 0.5 (light background) → dark text
- If luminance ≤ 0.5 (dark background) → light text

## Testing
1. Insert a table
2. Apply different background colors to cells
3. Verify text contrast is automatically adjusted for readability